### PR TITLE
Fragment View

### DIFF
--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,28 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface HintProps {
+  children: React.ReactNode;
+  text: string;
+  side?: "top" | "bottom" | "left" | "right";
+  alignment?: "start" | "center" | "end";
+};
+
+export const Hint = ({ children, text, side = "top", alignment = "center" }: HintProps) => {
+  return (
+    <TooltipProvider>
+      <Tooltip> 
+        <TooltipTrigger asChild>
+          {children}
+        </TooltipTrigger>
+        <TooltipContent side={side} align={alignment}>
+          {text}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/modules/projects/ui/components/fragment-web.tsx
+++ b/src/modules/projects/ui/components/fragment-web.tsx
@@ -1,0 +1,68 @@
+import { Hint } from "@/components/hint";
+import { Button } from "@/components/ui/button";
+import { Fragment } from "@/generated/prisma";
+import { ExternalLinkIcon, RefreshCcwIcon } from "lucide-react";
+import { useState } from "react";
+
+interface FragmentWebProps {
+  data: Fragment;
+}
+
+export function FragmentWeb({ data }: FragmentWebProps) {
+  const [fragmentKey, setFragmentKey] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  const onRefresh = () => {
+    setFragmentKey((prev) => prev + 1);
+  };
+
+  const handleCopy = () => {
+    if (!data.sandboxUrl) return;
+    navigator.clipboard.writeText(data.sandboxUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="flex flex-col w-full h-full">
+      <div className="p-2 border-b bg-sidebar flex items-center gap-x-2">
+        <Hint text="Refresh" side="bottom" alignment="start">
+          <Button size={"sm"} variant="outline" onClick={onRefresh}>
+            <RefreshCcwIcon className="size-4" />
+          </Button>
+        </Hint>
+        <Hint text="Click to copy" side="bottom" alignment="start">
+        <Button 
+          size={"sm"} 
+          variant="outline" 
+          className="flex-1 justify-start text-start font-normal" 
+          disabled={!data.sandboxUrl || copied} 
+          onClick={handleCopy}
+        >
+          <span className="truncate">{data.sandboxUrl}</span>
+        </Button>
+        </Hint>
+        <Hint text="Open in new tab" side="bottom" alignment="start">
+          <Button 
+            size={"sm"} 
+            disabled={!data.sandboxUrl} 
+            variant={"outline"} 
+            onClick={() => {
+              if (!data.sandboxUrl) return;
+              window.open(data.sandboxUrl, "_blank");
+            }}
+          >
+            <ExternalLinkIcon />
+          </Button>
+        </Hint>
+      </div>
+      <iframe
+        key={fragmentKey}
+        className="h-full w-full"
+        sandbox="allow-scripts allow-same-origin allow-forms"
+        loading="lazy"
+        src={data.sandboxUrl}
+      />
+    </div>
+  );
+};

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -11,6 +11,7 @@ import {
 import { ProjectHeader } from "../components/project-header";
 import { MessagesContainer } from "../components/messages-container";
 import { Fragment } from "@/generated/prisma";
+import { FragmentWeb } from "../components/fragment-web";
 
 interface ProjectViewProps {
 	projectId: string;
@@ -46,7 +47,7 @@ export const ProjectView = ({ projectId }: ProjectViewProps) => {
 					defaultSize={65}
 					minSize={50}
 				>
-					TODO: Previews
+					{activeFragment && <FragmentWeb data={activeFragment} />}
 				</ResizablePanel>
 
 			</ResizablePanelGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a reusable Hint tooltip component for contextual guidance on hover/focus.
  - Introduced a Web Fragment preview pane in the Project view, shown when a fragment is selected.
  - Preview controls include:
    - Refresh to reload the preview.
    - Copy link with brief “copied” feedback.
    - Open in a new tab.
  - Controls gracefully disable when a preview link isn’t available, improving clarity and preventing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->